### PR TITLE
kinetic on Jetson TX1, zed_wrapper_node compiling error: cannot find -lopencv_dep_cudart

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,12 @@ exec_program(uname ARGS -p OUTPUT_VARIABLE CMAKE_SYSTEM_NAME2)
 if ( CMAKE_SYSTEM_NAME2 MATCHES "aarch64" ) # Jetson TX1
     SET(OCV_VERSION "2.4")
     SET(CUDA_VERSION "8.0")
-    SET(CUDA_USE_STATIC_CUDA_RUNTIME OFF)
+    
+    unset(CUDA_USE_STATIC_CUDA_RUNTIME CACHE)
+    option(CUDA_USE_STATIC_CUDA_RUNTIME OFF)
+    message ("CUDA_USE_STATIC_CUDA_RUNTIME : ${CUDA_USE_STATIC_CUDA_RUNTIME}")
+    ##to prevent from opencv_dep_cudart dependencies error...
+    ## cmake with -DCUDA_USE_STATIC_CUDA_RUNTIME=false can also be called.
 else() # Ubuntu Desktop
     SET(OCV_VERSION "3.1")
     SET(CUDA_VERSION "8.0")


### PR DESCRIPTION
ros kinetic, zed_wrapper_node, compiling error on Jetson TX1.
Message error is "cannot find -lopencv_dep_cudart".

Correction on CMkaefile.txt
