### PR TITLE
Publish odom when point cloud is subscribed

### DIFF
--- a/src/zed_wrapper_nodelet.cpp
+++ b/src/zed_wrapper_nodelet.cpp
@@ -731,7 +731,7 @@ namespace zed_wrapper {
                     }
 
                     // Publish the odometry if someone has subscribed to
-                    if (odom_SubNumber > 0) {
+                    if (odom_SubNumber > 0 || cloud_SubNumber > 0) {
                         zed.getPosition(pose);
                         // Transform ZED pose in TF2 Transformation
                         tf2::Transform camera_transform;


### PR DESCRIPTION
Publish odometry data when point cloud is subscribed. This allows to only subscribe point cloud and still have it in a transformed frame.
To test you can run `roslaunch zed_wrapper zed.launch` and add cloud topic in `rviz` with `map` as `fixed frame`.