### PR TITLE
Fixed assignment of covariances in the IMU message

### DIFF
--- a/zed_wrapper/src/nodelet/src/zed_wrapper_nodelet.cpp
+++ b/zed_wrapper/src/nodelet/src/zed_wrapper_nodelet.cpp
@@ -1375,7 +1375,7 @@ namespace zed_wrapper {
             imu_msg.linear_acceleration.y = mSignY * imu_data.linear_acceleration[mIdxY];
             imu_msg.linear_acceleration.z = mSignZ * imu_data.linear_acceleration[mIdxZ];
 
-            for (int i = 0; i < 3; i += 3) {
+            for (int i = 0; i < 3; ++i) {
                 imu_msg.orientation_covariance[i * 3 + 0] =
                     imu_data.orientation_covariance.r[i * 3 + mIdxX];
                 imu_msg.orientation_covariance[i * 3 + 1] =
@@ -1413,7 +1413,7 @@ namespace zed_wrapper {
             imu_raw_msg.linear_acceleration.z =
                 mSignZ * imu_data.linear_acceleration[mIdxZ];
 
-            for (int i = 0; i < 3; i += 3) {
+            for (int i = 0; i < 3; ++i) {
                 imu_raw_msg.linear_acceleration_covariance[i * 3 + 0] =
                     imu_data.linear_acceleration_convariance.r[i * 3 + mIdxX];
                 imu_raw_msg.linear_acceleration_covariance[i * 3 + 1] =


### PR DESCRIPTION
Possible fix for #305. The covariances now looks reasonable.