### PR TITLE
Fix catkin_make install : directory file "params"

### DIFF
--- a/zed_wrapper/CMakeLists.txt
+++ b/zed_wrapper/CMakeLists.txt
@@ -171,5 +171,5 @@ install(FILES
 install(DIRECTORY
   launch
   urdf
-  param
+  params
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})


### PR DESCRIPTION
During the command "catkin_make install", the folder "param" is not found. Indeed, the folder's name is now "params".