### PR TITLE
Fix diagnostic message for contrast dyn reconfigure

### DIFF
--- a/zed_wrapper/src/nodelet/src/zed_wrapper_nodelet.cpp
+++ b/zed_wrapper/src/nodelet/src/zed_wrapper_nodelet.cpp
@@ -1952,7 +1952,7 @@ void ZEDWrapperNodelet::dynamicReconfCallback(zed_wrapper::ZedConfig& config, ui
 
     case CONTRAST:
         mCamContrast = config.contrast;
-        NODELET_INFO("Reconfigure image brightness: %d", mCamBrightness);
+        NODELET_INFO("Reconfigure image contrast: %d", mCamContrast);
         mDynParMutex.unlock();
         //NODELET_DEBUG_STREAM( "dynamicReconfCallback MUTEX UNLOCK");
         break;


### PR DESCRIPTION
Nit-pick : fix the NODELET_INFO message printed when changing dynamic reconfigure contrast setting.

Not a big deal, but since I ran across it figured I'd mention it, and providing a PR seemed the quickest way to report it.