### PR TITLE
Set mTriggerAutoWB on startup if mCamAutoWB is set - 

### DIFF
--- a/zed_wrapper/src/nodelet/src/zed_wrapper_nodelet.cpp
+++ b/zed_wrapper/src/nodelet/src/zed_wrapper_nodelet.cpp
@@ -776,6 +776,9 @@ void ZEDWrapperNodelet::readParameters() {
     if (mCamAutoExposure) {
         mTriggerAutoExposure = true;
     }
+    if (mCamAutoWB) {
+        mTriggerAutoWB = true;
+    }
     // <---- Dynamic
 
 }


### PR DESCRIPTION
Mirror the behavior of mTriggerAutoExposure

This should force the code to make a call to `setCameraSettings(sl::VIDEO_SETTINGS::WHITEBALANCE_AUTO, 1);` if mCamAutoWB is set via params at startup.  