### PR TITLE
 Fix duplicated IMU timestamp issue

### DIFF
--- a/zed_nodelets/src/zed_nodelet/include/zed_wrapper_nodelet.hpp
+++ b/zed_nodelets/src/zed_nodelet/include/zed_wrapper_nodelet.hpp
@@ -1,4 +1,4 @@
-#ifndef ZED_WRAPPER_NODELET_H
+﻿#ifndef ZED_WRAPPER_NODELET_H
 #define ZED_WRAPPER_NODELET_H
 
 ///////////////////////////////////////////////////////////////////////////
@@ -508,6 +508,7 @@ private:
 
     bool mPublishTf;
     bool mPublishMapTf;
+    bool mPublishImuTf;
     bool mCameraFlip;
     bool mCameraSelfCalib;
 
@@ -551,11 +552,14 @@ private:
     ros::Time mFrameTimestamp;
 
     // Positional Tracking variables
-    sl::Pose mLastZedPose; // Sensor to Map transform
+    sl::Pose mLastZedPose; // Sensor to Map transform    
     sl::Transform mInitialPoseSl;
     std::vector<float> mInitialBasePose;
     std::vector<geometry_msgs::PoseStamped> mOdomPath;
     std::vector<geometry_msgs::PoseStamped> mMapPath;
+
+    // IMU TF
+    tf2::Transform mLastImuPose;
 
     // TF Transforms
     tf2::Transform mMap2OdomTransf;         // Coordinates of the odometry frame in map frame

--- a/zed_nodelets/src/zed_nodelet/src/zed_wrapper_nodelet.cpp
+++ b/zed_nodelets/src/zed_nodelet/src/zed_wrapper_nodelet.cpp
@@ -33,6 +33,8 @@
 #include "visualization_msgs/Marker.h"
 #include "visualization_msgs/MarkerArray.h"
 
+//#define DEBUG_SENS_TS 1
+
 namespace zed_nodelets {
 
 #ifndef DEG2RAD
@@ -513,7 +515,7 @@ void ZEDWrapperNodelet::onInit() {
             }
 
             mFrameTimestamp = ros::Time::now();
-            mImuTimer = mNhNs.createTimer(ros::Duration(1.0 / mSensPubRate),
+            mImuTimer = mNhNs.createTimer(ros::Duration(1.0 / (mSensPubRate*1.5) ),
                                           &ZEDWrapperNodelet::pubSensCallback, this);
             mSensPeriodMean_usec.reset(new sl_tools::CSmartMean(mSensPubRate / 2));
 
@@ -807,6 +809,8 @@ void ZEDWrapperNodelet::readParameters() {
     mNhNs.param<bool>("pos_tracking/publish_map_tf", mPublishMapTf, true);
     NODELET_INFO_STREAM(" * Broadcast map pose TF\t-> " << (mPublishTf ? (mPublishMapTf ? "ENABLED" : "DISABLED") :
                                                                          "DISABLED"));
+    mNhNs.param<bool>("sensors/publish_imu_tf", mPublishImuTf, true);
+    NODELET_INFO_STREAM(" * Broadcast IMU pose TF\t-> " << ( mPublishImuTf ? "ENABLED" : "DISABLED" ) );
     // <---- TF broadcasting
 
     // ----> Dynamic
@@ -1582,6 +1586,8 @@ void ZEDWrapperNodelet::publishOdomFrame(tf2::Transform odomTransf, ros::Time t)
     transformStamped.transform = tf2::toMsg(odomTransf);
     // Publish transformation
     mTransformOdomBroadcaster.sendTransform(transformStamped);
+
+    //NODELET_INFO_STREAM( "Published ODOM TF with TS: " << t );
 }
 
 void ZEDWrapperNodelet::publishPoseFrame(tf2::Transform baseTransform, ros::Time t) {
@@ -1605,6 +1611,8 @@ void ZEDWrapperNodelet::publishPoseFrame(tf2::Transform baseTransform, ros::Time
     transformStamped.transform = tf2::toMsg(baseTransform);
     // Publish transformation
     mTransformPoseBroadcaster.sendTransform(transformStamped);
+
+    //NODELET_INFO_STREAM( "Published POSE TF with TS: " << t );
 }
 
 void ZEDWrapperNodelet::publishImuFrame(tf2::Transform imuTransform, ros::Time t) {
@@ -1628,6 +1636,8 @@ void ZEDWrapperNodelet::publishImuFrame(tf2::Transform imuTransform, ros::Time t
     transformStamped.transform = tf2::toMsg(imuTransform);
     // Publish transformation
     mTransformImuBroadcaster.sendTransform(transformStamped);
+
+    //NODELET_INFO_STREAM( "Published IMU TF with TS: " << t );
 }
 
 void ZEDWrapperNodelet::publishImage(sensor_msgs::ImagePtr imgMsgPtr, sl::Mat img,
@@ -1642,7 +1652,7 @@ void ZEDWrapperNodelet::publishDepth(sensor_msgs::ImagePtr imgMsgPtr, sl::Mat de
 
     mDepthCamInfoMsg->header.stamp = t;
 
-    NODELET_DEBUG_STREAM("mOpenniDepthMode: " << mOpenniDepthMode);
+    //NODELET_DEBUG_STREAM("mOpenniDepthMode: " << mOpenniDepthMode);
 
     if (!mOpenniDepthMode) {
         sl_tools::imageToROSmsg(imgMsgPtr, depth, mDepthOptFrameId, t);
@@ -1834,7 +1844,7 @@ void ZEDWrapperNodelet::pubFusedPointCloudCallback(const ros::TimerEvent& e) {
 
     if (pointcloudFusedMsg->width != ptsCount || pointcloudFusedMsg->height != 1) {
         // Initialize Point Cloud message
-        // https://github.com/ros/common_msgs/blob/jade-devel/sensor_msgs/include/sensor_msgs/point_cloud2_iterator.h        
+        // https://github.com/ros/common_msgs/blob/jade-devel/sensor_msgs/include/sensor_msgs/point_cloud2_iterator.h
         pointcloudFusedMsg->header.frame_id = mMapFrameId; // Set the header values of the ROS message
         pointcloudFusedMsg->is_bigendian = false;
         pointcloudFusedMsg->is_dense = false;
@@ -2591,8 +2601,9 @@ void ZEDWrapperNodelet::pubSensCallback(const ros::TimerEvent& e) {
     ros::Time ts_imu;
     ros::Time ts_baro;
     ros::Time ts_mag;
-    ros::Time ts_mag_raw;
+    //ros::Time ts_mag_raw;
 
+    static ros::Time lastTs_imu = ros::Time();
     static ros::Time lastTs_baro = ros::Time();
     static ros::Time lastT_mag = ros::Time();
     //static ros::Time lastT_mag_raw = ros::Time();
@@ -2624,7 +2635,7 @@ void ZEDWrapperNodelet::pubSensCallback(const ros::TimerEvent& e) {
             ts_imu = mFrameTimestamp;
             ts_baro = mFrameTimestamp;
             ts_mag = mFrameTimestamp;
-            ts_mag_raw = mFrameTimestamp;
+            //ts_mag_raw = mFrameTimestamp;
         } else {
             ts_imu = sl_tools::slTime2Ros(sens_data.imu.timestamp);
             ts_baro = sl_tools::slTime2Ros(sens_data.barometer.timestamp);
@@ -2633,14 +2644,22 @@ void ZEDWrapperNodelet::pubSensCallback(const ros::TimerEvent& e) {
         }
     }
 
+    bool new_imu_data = ts_imu!=lastTs_imu;
+    bool new_baro_data = ts_baro!=lastTs_baro;
+    bool new_mag_data = ts_mag!=lastT_mag;
+
+    if( !new_imu_data && !new_baro_data && !new_mag_data) {
+        return;
+    }
+
     if( mZedRealCamModel == sl::MODEL::ZED2 ) {
         // Update temperatures for Diagnostic
         sens_data.temperature.get( sl::SensorsData::TemperatureData::SENSOR_LOCATION::ONBOARD_LEFT, mTempLeft);
         sens_data.temperature.get( sl::SensorsData::TemperatureData::SENSOR_LOCATION::ONBOARD_RIGHT, mTempRight);
     }
 
-    if (totSub<1) { // Nothing to publish
-        return;
+    if(totSub<1 && !mPublishImuTf) {
+        return; // Nothing to publish
     }
 
     if( imu_SubNumber > 0 || imu_RawSubNumber > 0 ||
@@ -2664,6 +2683,15 @@ void ZEDWrapperNodelet::pubSensCallback(const ros::TimerEvent& e) {
         sensor_msgs::TemperaturePtr imuTempMsg = boost::make_shared<sensor_msgs::Temperature>();
 
         imuTempMsg->header.stamp = ts_imu;
+
+#ifdef DEBUG_SENS_TS
+        static ros::Time old_ts;
+        if(old_ts==imuTempMsg->header.stamp) {
+            NODELET_WARN_STREAM("Publishing IMU data with old timestamp " << old_ts );
+        }
+        old_ts = imuTempMsg->header.stamp;
+#endif
+
         imuTempMsg->header.frame_id = mImuFrameId;
         float imu_temp;
         sens_data.temperature.get( sl::SensorsData::TemperatureData::SENSOR_LOCATION::IMU, imu_temp);
@@ -2673,14 +2701,21 @@ void ZEDWrapperNodelet::pubSensCallback(const ros::TimerEvent& e) {
         mPubImuTemp.publish(imuTempMsg);
     }
 
-
-    if( sens_data.barometer.is_available && lastTs_baro != ts_baro ) {
+    if( sens_data.barometer.is_available && new_baro_data ) {
         lastTs_baro = ts_baro;
 
         if( pressSubNumber>0 ) {
             sensor_msgs::FluidPressurePtr pressMsg = boost::make_shared<sensor_msgs::FluidPressure>();
 
             pressMsg->header.stamp = ts_baro;
+
+#ifdef DEBUG_SENS_TS
+            static ros::Time old_ts;
+            if(old_ts==pressMsg->header.stamp) {
+                NODELET_WARN_STREAM("Publishing BARO data with old timestamp " << old_ts );
+            }
+            old_ts = pressMsg->header.stamp;
+#endif
             pressMsg->header.frame_id = mBaroFrameId;
             pressMsg->fluid_pressure = sens_data.barometer.pressure * 1e-2; // Pascal
             pressMsg->variance = 1.0585e-2;
@@ -2692,6 +2727,15 @@ void ZEDWrapperNodelet::pubSensCallback(const ros::TimerEvent& e) {
             sensor_msgs::TemperaturePtr tempLeftMsg = boost::make_shared<sensor_msgs::Temperature>();
 
             tempLeftMsg->header.stamp = ts_baro;
+
+#ifdef DEBUG_SENS_TS
+            static ros::Time old_ts;
+            if(old_ts==tempLeftMsg->header.stamp) {
+                NODELET_WARN_STREAM("Publishing BARO data with old timestamp " << old_ts );
+            }
+            old_ts = tempLeftMsg->header.stamp;
+#endif
+
             tempLeftMsg->header.frame_id = mTempLeftFrameId;
             tempLeftMsg->temperature = static_cast<double>(mTempLeft);
             tempLeftMsg->variance = 0.0;
@@ -2703,6 +2747,15 @@ void ZEDWrapperNodelet::pubSensCallback(const ros::TimerEvent& e) {
             sensor_msgs::TemperaturePtr tempRightMsg = boost::make_shared<sensor_msgs::Temperature>();
 
             tempRightMsg->header.stamp = ts_baro;
+
+#ifdef DEBUG_SENS_TS
+            static ros::Time old_ts;
+            if(old_ts==tempRightMsg->header.stamp) {
+                NODELET_WARN_STREAM("Publishing BARO data with old timestamp " << old_ts );
+            }
+            old_ts = tempRightMsg->header.stamp;
+#endif
+
             tempRightMsg->header.frame_id = mTempRightFrameId;
             tempRightMsg->temperature = static_cast<double>(mTempRight);
             tempRightMsg->variance = 0.0;
@@ -2711,13 +2764,22 @@ void ZEDWrapperNodelet::pubSensCallback(const ros::TimerEvent& e) {
         }
     }
 
-    if( imu_MagSubNumber>0 ) {
-        if( sens_data.magnetometer.is_available && lastT_mag != ts_mag ) {
+    if( imu_MagSubNumber>0) {
+        if( sens_data.magnetometer.is_available && new_mag_data ) {
             lastT_mag = ts_mag;
 
             sensor_msgs::MagneticFieldPtr magMsg = boost::make_shared<sensor_msgs::MagneticField>();
 
             magMsg->header.stamp = ts_mag;
+
+#ifdef DEBUG_SENS_TS
+            static ros::Time old_ts;
+            if(old_ts==magMsg->header.stamp) {
+                NODELET_WARN_STREAM("Publishing MAG data with old timestamp " << old_ts );
+            }
+            old_ts = magMsg->header.stamp;
+#endif
+
             magMsg->header.frame_id = mMagFrameId;
             magMsg->magnetic_field.x = sens_data.magnetometer.magnetic_field_calibrated.x*1e-6; // Tesla
             magMsg->magnetic_field.y = sens_data.magnetometer.magnetic_field_calibrated.y*1e-6; // Tesla
@@ -2762,10 +2824,24 @@ void ZEDWrapperNodelet::pubSensCallback(const ros::TimerEvent& e) {
     //        }
     //    }
 
-    if (imu_SubNumber > 0) {
+    if( (imu_SubNumber > 0 || mPublishImuTf) && new_imu_data) {
+        lastTs_imu = ts_imu;
+
         sensor_msgs::ImuPtr imuMsg = boost::make_shared<sensor_msgs::Imu>();
 
         imuMsg->header.stamp = ts_imu;
+
+#ifdef DEBUG_SENS_TS
+        static ros::Time old_ts;
+        if(old_ts==imuMsg->header.stamp) {
+            NODELET_WARN_STREAM("Publishing IMU data with old timestamp " << old_ts );
+        } else {
+            NODELET_INFO_STREAM("Publishing IMU data with new timestamp. Freq: " << 1./(ts_imu.toSec()-old_ts.toSec()) );
+            old_ts = imuMsg->header.stamp;
+
+        }
+#endif
+
         imuMsg->header.frame_id = mImuFrameId;
 
         imuMsg->orientation.x = sens_data.imu.pose.getOrientation()[0];
@@ -2815,10 +2891,12 @@ void ZEDWrapperNodelet::pubSensCallback(const ros::TimerEvent& e) {
                     sens_data.imu.angular_velocity_covariance.r[r * 3 + 2] * DEG2RAD * DEG2RAD;
         }
 
-        mPubImu.publish(imuMsg);
+        if(imu_SubNumber > 0) {
+            mPubImu.publish(imuMsg);
+        }
     }
 
-    if (imu_RawSubNumber > 0) {
+    if (imu_RawSubNumber > 0 && new_imu_data) {
         sensor_msgs::ImuPtr imuRawMsg = boost::make_shared<sensor_msgs::Imu>();
 
         imuRawMsg->header.stamp = ts_imu;
@@ -2862,52 +2940,72 @@ void ZEDWrapperNodelet::pubSensCallback(const ros::TimerEvent& e) {
         mPubImuRaw.publish(imuRawMsg);
     }
 
-    // Publish IMU tf
-    // Camera to pose transform from TF buffer
-    tf2::Transform cam_to_odom;
+    if(new_imu_data && mPublishImuTf) {
+        // Publish odometry tf only if enabled
+        if (mPublishTf) {
+            if(!mTrackingReady) {
+                return;
+            }
 
-    //std::string poseFrame;
-    static bool first_error = true;
+            publishOdomFrame(mOdom2BaseTransf, ts_imu); // publish the base Frame in odometry frame
 
-    // Look up the transformation from imu frame to odom link
-    try {
-        // Save the transformation from base to frame
-        geometry_msgs::TransformStamped c20 =
-                mTfBuffer->lookupTransform(mOdometryFrameId, mCameraFrameId, ros::Time(0));
-        // Get the TF2 transformation
-        tf2::fromMsg(c20.transform, cam_to_odom);
-    } catch (tf2::TransformException& ex) {
-        if(!first_error) {
-            NODELET_DEBUG_THROTTLE(1.0, "Transform error: %s", ex.what());
-            NODELET_WARN_THROTTLE(1.0, "The tf from '%s' to '%s' is not available.",
-                                  mCameraFrameId.c_str(), mMapFrameId.c_str());
-            NODELET_WARN_THROTTLE(1.0, "Note: one of the possible cause of the problem is the absense of a publisher "
-                                       "of the base_link -> odom transform. "
-                                       "This happens if `publish_tf` is `false` and no other nodes publish the "
-                                       "TF chain '%s' -> '%s' -> '%s'",
-                                  mOdometryFrameId.c_str(), mBaseFrameId.c_str(), mCameraFrameId.c_str());
-            first_error=false;
+            if (mPublishMapTf) {
+                publishPoseFrame(mMap2OdomTransf, ts_imu); // publish the odometry Frame in map frame
+            }
         }
 
-        return;
+        // Publish IMU tf
+        // Left camera to odom transform from TF buffer
+        tf2::Transform cam_to_odom;
+
+        //std::string poseFrame;
+        static bool first_error = false;
+
+        // Look up the transformation from imu frame to odom link
+        try {
+            // Save the transformation from base to frame
+            geometry_msgs::TransformStamped c2o =
+                    mTfBuffer->lookupTransform(mOdometryFrameId, mCameraFrameId, ros::Time(0), ros::Duration(0.1));
+            // Get the TF2 transformation
+            tf2::fromMsg(c2o.transform, cam_to_odom);
+        } catch (tf2::TransformException& ex) {
+            if(!first_error) {
+                NODELET_DEBUG_THROTTLE(1.0, "Transform error: %s", ex.what());
+                NODELET_WARN_THROTTLE(1.0, "The tf from '%s' to '%s' is not available.",
+                                      mCameraFrameId.c_str(), mMapFrameId.c_str());
+                NODELET_WARN_THROTTLE(1.0, "Note: one of the possible cause of the problem is the absense of a publisher "
+                                           "of the base_link -> odom transform. "
+                                           "This happens if `publish_tf` is `false` and no other nodes publish the "
+                                           "TF chain '%s' -> '%s' -> '%s'",
+                                      mOdometryFrameId.c_str(), mBaseFrameId.c_str(), mCameraFrameId.c_str());
+                first_error=false;
+            }
+
+            return;
+        }
+
+        // ----> Update IMU pose for TF
+
+        // IMU Quaternion in Map frame
+        tf2::Quaternion imu_q;
+        imu_q.setX(sens_data.imu.pose.getOrientation()[0]);
+        imu_q.setY(sens_data.imu.pose.getOrientation()[1]);
+        imu_q.setZ(sens_data.imu.pose.getOrientation()[2]);
+        imu_q.setW(sens_data.imu.pose.getOrientation()[3]);
+
+        // Pose Quaternion from ZED Camera
+        tf2::Quaternion odom_q = cam_to_odom.getRotation();
+        // Difference between IMU and ZED Quaternion
+        tf2::Quaternion delta_q = imu_q * odom_q.inverse();
+
+        mLastImuPose.setIdentity();
+        mLastImuPose.setRotation(delta_q);
+
+        publishImuFrame(mLastImuPose, ts_imu);
+        // <---- Update IMU pose for TF
     }
-
-    // IMU Quaternion in Map frame
-    tf2::Quaternion imu_q;
-    imu_q.setX(sens_data.imu.pose.getOrientation()[0]);
-    imu_q.setY(sens_data.imu.pose.getOrientation()[1]);
-    imu_q.setZ(sens_data.imu.pose.getOrientation()[2]);
-    imu_q.setW(sens_data.imu.pose.getOrientation()[3]);
-    // Pose Quaternion from ZED Camera
-    tf2::Quaternion map_q = cam_to_odom.getRotation();
-    // Difference between IMU and ZED Quaternion
-    tf2::Quaternion delta_q = imu_q * map_q.inverse();
-    tf2::Transform imu_pose;
-    imu_pose.setIdentity();
-    imu_pose.setRotation(delta_q);
-
-    publishImuFrame(imu_pose, mFrameTimestamp); // publish the imu Frame
 }
+
 
 void ZEDWrapperNodelet::device_poll_thread_func() {
     ros::Rate loop_rate(mCamFrameRate);
@@ -3492,16 +3590,18 @@ void ZEDWrapperNodelet::device_poll_thread_func() {
                 oldStatus = mTrackingStatus;
             }
 
-            // Publish pose tf only if enabled
-            if (mPublishTf) {
-                // Note, the frame is published, but its values will only change if
-                // someone has subscribed to odom
-                publishOdomFrame(mOdom2BaseTransf, stamp); // publish the base Frame in odometry frame
-
-                if (mPublishMapTf) {
+            if(mZedRealCamModel == sl::MODEL::ZED || !mPublishImuTf) { // otherwise TFs are published together with sensor data
+                // Publish pose tf only if enabled
+                if(mPublishTf) {
                     // Note, the frame is published, but its values will only change if
-                    // someone has subscribed to map
-                    publishPoseFrame(mMap2OdomTransf, stamp); // publish the odometry Frame in map frame
+                    // someone has subscribed to odom
+                    publishOdomFrame(mOdom2BaseTransf, stamp); // publish the base Frame in odometry frame
+
+                    if(mPublishMapTf) {
+                        // Note, the frame is published, but its values will only change if
+                        // someone has subscribed to map
+                        publishPoseFrame(mMap2OdomTransf, stamp); // publish the odometry Frame in map frame
+                    }
                 }
             }
 
@@ -3563,20 +3663,22 @@ void ZEDWrapperNodelet::device_poll_thread_func() {
         } else {
             NODELET_DEBUG_THROTTLE(5.0, "No topics subscribed by users");
 
-            // Publish odometry tf only if enabled
-            if (mPublishTf) {
-                ros::Time t;
+            if(mZedRealCamModel == sl::MODEL::ZED || !mPublishImuTf) {
+                // Publish odometry tf only if enabled
+                if (mPublishTf) {
+                    ros::Time t;
 
-                if (mSvoMode) {
-                    t = ros::Time::now();
-                } else {
-                    t = sl_tools::slTime2Ros(mZed.getTimestamp(sl::TIME_REFERENCE::CURRENT));
-                }
+                    if (mSvoMode) {
+                        t = ros::Time::now();
+                    } else {
+                        t = sl_tools::slTime2Ros(mZed.getTimestamp(sl::TIME_REFERENCE::CURRENT));
+                    }
 
-                publishOdomFrame(mOdom2BaseTransf, mFrameTimestamp); // publish the base Frame in odometry frame
+                    publishOdomFrame(mOdom2BaseTransf, mFrameTimestamp); // publish the base Frame in odometry frame
 
-                if (mPublishMapTf) {
-                    publishPoseFrame(mMap2OdomTransf, mFrameTimestamp); // publish the odometry Frame in map frame
+                    if (mPublishMapTf) {
+                        publishPoseFrame(mMap2OdomTransf, mFrameTimestamp); // publish the odometry Frame in map frame
+                    }
                 }
             }
 

--- a/zed_wrapper/params/zed2.yaml
+++ b/zed_wrapper/params/zed2.yaml
@@ -14,6 +14,7 @@ pos_tracking:
 
 sensors:
     sensors_timestamp_sync:     false           # Synchronize Sensors messages timestamp with latest received frame
+    publish_imu_tf:             true            # publish `IMU -> <cam_name>_left_camera_frame` TF
 
 object_detection:
     od_enabled:                 false           # True to enable Object Detection [only ZED 2]

--- a/zed_wrapper/params/zedm.yaml
+++ b/zed_wrapper/params/zedm.yaml
@@ -14,3 +14,4 @@ pos_tracking:
 
 sensors:
     sensors_timestamp_sync:     false           # Synchronize Sensors messages timestamp with latest received frame
+    publish_imu_tf:             true            # publish `IMU -> <cam_name>_left_camera_frame` TF


### PR DESCRIPTION
- Add new parameter `sensors/publish_imu_tf` to enable/disable IMU TF broadcasting
- Fix duplicated IMU timestamp issue (see ticket #577)
- Fix problem with IMU TF in Rviz: `odom` and `zed_camera_center` TFs
are now published at the same frequency of the IMU TF, if available)
- IMU TF is now published even if the IMU topic is not subscribed