### PR TITLE
Allow publishing IMU TF without Odom TF

### DIFF
--- a/zed_nodelets/src/zed_nodelet/src/zed_wrapper_nodelet.cpp
+++ b/zed_nodelets/src/zed_nodelet/src/zed_wrapper_nodelet.cpp
@@ -3063,13 +3063,14 @@ void ZEDWrapperNodelet::publishSensData(ros::Time t)
     {
       publishPoseFrame(mMap2OdomTransf, ts_imu);  // publish the odometry Frame in map frame
     }
-
-    if (mPublishImuTf && !mStaticImuFramePublished)
-    {
-      publishStaticImuFrame();
-    }
   }
   // <---- Publish odometry tf only if enabled
+
+  if (mPublishImuTf && !mStaticImuFramePublished)
+  {
+    NODELET_DEBUG("Publishing static IMU TF");
+    publishStaticImuFrame();
+  }
 
   if (mZedRealCamModel == sl::MODEL::ZED2 || mZedRealCamModel == sl::MODEL::ZED2i)
   {


### PR DESCRIPTION
Currently `publish_imu_tf` parameter only works if the `publish_tf` parameter is set to true. For this reason, there is no way to publish static IMU TF without also publishing the `odom` TF.  This PR changes this behavior by making these two options independent.