### PR TITLE
zero Rz cross covariance terms

### DIFF
--- a/zed_nodelets/src/zed_nodelet/src/zed_wrapper_nodelet.cpp
+++ b/zed_nodelets/src/zed_nodelet/src/zed_wrapper_nodelet.cpp
@@ -1721,7 +1721,7 @@ void ZEDWrapperNodelet::publishOdom(tf2::Transform odom2baseTransf, sl::Pose& sl
         if (mTwoDMode) {
             if (i == 14 || i == 21 || i == 28) {
                 odomMsg->pose.covariance[i] = 1e-9; // Very low covariance if 2D mode
-            } else if ((i >= 2 && i <= 4) || (i >= 8 && i <= 10) || (i >= 12 && i <= 13) || (i >= 15 && i <= 16) || (i >= 18 && i <= 20) || (i == 22) || (i >= 24 && i <= 27)) {
+            } else if ((i >= 2 && i <= 4) || (i >= 8 && i <= 10) || (i >= 12 && i <= 13) || (i >= 15 && i <= 20) || (i >= 22 && i <= 27) || (i == 29) || (i >= 32 && i <= 34)) {
                 odomMsg->pose.covariance[i] = 0.0;
             }
         }


### PR DESCRIPTION
This pull request zeroes the cross covariance terms between R_z & Z, R_z & R_x, and R_z & R_y when the camera is in 2D mode.

The matrix indexes for the 6x6 covariance matrix from the [ROS PoseWithCovariance](https://docs.ros.org/en/noetic/api/geometry_msgs/html/msg/PoseWithCovariance.html) message for reference:
|     | x  | y  | z  | R_x | R_y | R_z |
|-----|----|----|----|-----|-----|-----|
| x   | 0  | 1  | 2  | 3   | 4   | 5   |
| y   | 6  | 7  | 8  | 9   | 10  | 11  |
| z   | 12 | 13 | 14 | 15  | 16  | 17  |
| R_x | 18 | 19 | 20 | 21  | 22  | 23  |
| R_y | 24 | 25 | 26 | 27  | 28  | 29  |
| R_z | 30 | 31 | 32 | 33  | 34  | 35  |

Currently only some of the cross-correlation terms are zeroed. A dash represents that the value is left unchanged.
|     | x | y | z    | R_x  | R_y  | R_z |
|-----|---|---|------|------|------|-----|
| x   | - | - | 0    | 0    | 0    | -   |
| y   | - | - | 0    | 0    | 0    | -   |
| z   | 0 | 0 | 1e-9 | 0    | 0    | -   |
| R_x | 0 | 0 | 0    | 1e-9 | 0    | -   |
| R_y | 0 | 0 | 0    | 0    | 1e-9 | -   |
| R_z | - | - | -    | -    | -    | -   |

The new behavior zeroes out the R_z cross correlation terms so you're essentially left with a covariance matrix that's only the X,Y, and Rz diagonal terms and their respective cross-correlation terms with each other.
|     | x | y | z    | R_x  | R_y  | R_z |
|-----|---|---|------|------|------|-----|
| x   | - | - | 0    | 0    | 0    | -   |
| y   | - | - | 0    | 0    | 0    | -   |
| z   | 0 | 0 | 1e-9 | 0    | 0    | 0   |
| R_x | 0 | 0 | 0    | 1e-9 | 0    | 0   |
| R_y | 0 | 0 | 0    | 0    | 1e-9 | 0   |
| R_z | - | - | 0    | 0    | 0    | -   |