### PR TITLE
Update zed_wrapper_nodelet.cpp

### DIFF
--- a/zed_nodelets/src/zed_nodelet/src/zed_wrapper_nodelet.cpp
+++ b/zed_nodelets/src/zed_nodelet/src/zed_wrapper_nodelet.cpp
@@ -4412,7 +4412,8 @@ void ZEDWrapperNodelet::processDetectedObjects(ros::Time t)
     for (auto data : objects.object_list) {
         objMsg->objects[idx].label = sl::toString(data.label).c_str();
         objMsg->objects[idx].sublabel = sl::toString(data.sublabel).c_str();
-        objMsg->objects[idx].label_id = data.id;
+        objMsg->objects[idx].label_id = data.raw_label;
+        objMsg->objects[idx].instance_id = data.id;
         objMsg->objects[idx].confidence = data.confidence;
 
         memcpy(&(objMsg->objects[idx].position[0]), &(data.position[0]), 3 * sizeof(float));


### PR DESCRIPTION
I have updated the writing of the Object message adding the instance id and writing correctly the label_id.
Previously the label_id was wrote using the id coming from the tracking algorithm and this can lead to errors because if there is an id switch or re-identification the class label (label_id) changes.