### PR TITLE
Fix plane publish counter typo

### DIFF
--- a/zed_nodelets/src/zed_nodelet/src/zed_wrapper_nodelet.cpp
+++ b/zed_nodelets/src/zed_nodelet/src/zed_wrapper_nodelet.cpp
@@ -5207,7 +5207,7 @@ void ZEDWrapperNodelet::clickedPtCallback(geometry_msgs::PointStampedConstPtr ms
 {
   // ----> Check for result subscribers
   uint32_t markerSubNumber = mPubMarker.getNumSubscribers();
-  uint32_t planeSubNumber = mPubMarker.getNumSubscribers();
+  uint32_t planeSubNumber = mPubPlane.getNumSubscribers();
 
   if ((markerSubNumber + planeSubNumber) == 0)
   {


### PR DESCRIPTION
I was wondering why planes weren't being generated except when the marker was visible. Turns out the counter only uses the marker topic and not the plane response topic. This PR fixes that.
