### PR TITLE
Fixed build in Windows, camera opening error fix

### DIFF
--- a/zed_nodelets/CMakeLists.txt
+++ b/zed_nodelets/CMakeLists.txt
@@ -120,7 +120,7 @@ set(LINK_LIBRARIES
   ${catkin_LIBRARIES}
   ${ZED_LIBRARIES}
   ${CUDA_LIBRARIES}
-  ${Booost_LIBRARIES}
+  ${Boost_LIBRARIES}
 )
 
 add_library(ZEDNodelets

--- a/zed_nodelets/CMakeLists.txt
+++ b/zed_nodelets/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.17)
 
 project(zed_nodelets)
 
@@ -30,8 +30,9 @@ if ( CMAKE_SYSTEM_NAME2 MATCHES "aarch64" ) # Jetson TX
     SET(CUDA_USE_STATIC_CUDA_RUNTIME OFF)
 endif()
 
-find_package(CUDA)
-checkPackage("CUDA" "CUDA not found, install it from:\n https://developer.nvidia.com/cuda-downloads")
+find_package(CUDAToolkit)
+set(CUDA_LIBRARIES CUDA::cudart CUDA::cuda_driver)
+checkPackage("CUDAToolkit" "CUDA not found, install it from:\n https://developer.nvidia.com/cuda-downloads")
 
 find_package(OpenMP)
 checkPackage("OpenMP" "OpenMP not found, please install it to improve performances: 'sudo apt install libomp-dev'")
@@ -40,6 +41,8 @@ if (OPENMP_FOUND)
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
     set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
 endif()
+
+find_package(Boost REQUIRED COMPONENTS filesystem)
 
 find_package(catkin REQUIRED COMPONENTS
     roscpp
@@ -96,7 +99,7 @@ set(RGBD_SENS_DEMUX_SRC ${CMAKE_CURRENT_SOURCE_DIR}/src/rgbd_sensors_demux_nodel
 # Specify locations of header files.
 set(INCLUDE_DIRS
     ${catkin_INCLUDE_DIRS}
-    ${CUDA_INCLUDE_DIRS}
+    ${Boost_INCLUDE_DIRS}
     ${ZED_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tools/include
     ${CMAKE_CURRENT_SOURCE_DIR}/src/zed_nodelet/include
@@ -105,19 +108,19 @@ set(INCLUDE_DIRS
 )
 
 link_directories(${ZED_LIBRARY_DIR})
-link_directories(${CUDA_LIBRARY_DIRS})
+link_directories(${CUDAToolkit_LIBRARY_DIR})
+link_directories(${Boost_LIBRARY_DIR})
 
 ###############################################################################
 
 ###############################################################################
 # ZED WRAPPER NODELET
 
-add_definitions(-std=c++11 -Wno-deprecated-declarations)
 set(LINK_LIBRARIES
   ${catkin_LIBRARIES}
   ${ZED_LIBRARIES}
   ${CUDA_LIBRARIES}
-  stdc++fs
+  ${Booost_LIBRARIES}
 )
 
 add_library(ZEDNodelets
@@ -126,6 +129,12 @@ add_library(ZEDNodelets
     ${RGBD_SENS_SYNC_SRC}
     ${RGBD_SENS_DEMUX_SRC}
 )
+set_target_properties(ZEDNodelets PROPERTIES CXX_STANDARD 11)
+
+if (NOT MSVC)
+    target_compile_options(ZEDNodelets PRIVATE -Wno-deprecated-declarations)
+endif()
+
 target_include_directories(ZEDNodelets PRIVATE ${INCLUDE_DIRS})
 target_link_libraries(ZEDNodelets ${LINK_LIBRARIES})
 add_dependencies(

--- a/zed_nodelets/src/tools/src/sl_tools.cpp
+++ b/zed_nodelets/src/tools/src/sl_tools.cpp
@@ -22,7 +22,7 @@
 #include <sys/stat.h>
 
 #include <boost/make_shared.hpp>
-#include <experimental/filesystem>  // for std::experimental::filesystem::absolute
+#include <boost/filesystem.hpp>  // for std::experimental::filesystem::absolute
 #include <sstream>
 #include <vector>
 
@@ -36,7 +36,7 @@ bool file_exist(const std::string& name)
   return (stat(name.c_str(), &buffer) == 0);
 }
 
-namespace fs = std::experimental::filesystem;
+namespace fs = boost::filesystem;
 std::string resolveFilePath(std::string file_path)
 {
   if (file_path.empty())

--- a/zed_nodelets/src/zed_nodelet/include/zed_wrapper_nodelet.hpp
+++ b/zed_nodelets/src/zed_nodelet/include/zed_wrapper_nodelet.hpp
@@ -699,7 +699,7 @@ private:
   // Zed object
   sl::InitParameters mZedParams;
   sl::Camera mZed;
-  unsigned int mZedSerialNumber;
+  unsigned int mZedSerialNumber = 0;
   sl::MODEL mZedUserCamModel;   // Camera model set by ROS Param
   sl::MODEL mZedRealCamModel;   // Real camera model by SDK API
   unsigned int mCamFwVersion;   // Camera FW version

--- a/zed_nodelets/src/zed_nodelet/src/zed_wrapper_nodelet.cpp
+++ b/zed_nodelets/src/zed_nodelet/src/zed_wrapper_nodelet.cpp
@@ -1394,7 +1394,7 @@ std::string ZEDWrapperNodelet::parseRoiPoly(const std::vector<std::vector<float>
   }
   else
   {
-    for (size_t i; i < poly_size; ++i)
+    for (size_t i = 0; i < poly_size; ++i)
     {
       if (in_poly[i].size() != 2)
       {
@@ -5374,7 +5374,7 @@ void ZEDWrapperNodelet::clickedPtCallback(geometry_msgs::PointStampedConstPtr ms
     {
       for (int p = 0; p < 3; p++)
       {
-        uint vIdx = mesh.triangles[t][p];
+        unsigned int vIdx = mesh.triangles[t][p];
         plane_marker->points[ptIdx].x = mesh.vertices[vIdx][0];
         plane_marker->points[ptIdx].y = mesh.vertices[vIdx][1];
         plane_marker->points[ptIdx].z = mesh.vertices[vIdx][2];

--- a/zed_wrapper/CMakeLists.txt
+++ b/zed_wrapper/CMakeLists.txt
@@ -47,7 +47,6 @@ link_directories(${CUDA_LIBRARY_DIRS})
 ###############################################################################
 # EXECUTABLE
 
-add_definitions(-std=c++11)
 set(LINK_LIBRARIES
   ${catkin_LIBRARIES}
 )
@@ -55,6 +54,7 @@ set(LINK_LIBRARIES
 add_executable(zed_wrapper_node ${NODE_SRC})
 target_link_libraries(zed_wrapper_node ${LINK_LIBRARIES})
 add_dependencies(zed_wrapper_node ${catkin_EXPORTED_TARGETS})
+set_target_properties(zed_wrapper_node PROPERTIES CXX_STANDARD 11)
 
 
 ###############################################################################


### PR DESCRIPTION
This PR fixes build in Windows (#946 zed-ros-wrapper only). Building in Windows may require [ddynamic_reconfigure](https://github.com/pal-robotics/ddynamic_reconfigure.git) in ros workspace src folder.
Also some uninitialized variables fixed, at least one of them was corrupting camera opening due to trash in serial number.